### PR TITLE
Avoid absolute url for local resources

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,16 +4,16 @@
 <head>
   <!-- <link rel="stylesheet/less" type="text/css" href="{{ SITEURL }}/theme/css/style.less">
   <script src="{{ SITEURL }}/theme/js/less-1.3.3.min.js" type="text/javascript"></script> test -->
-  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/style.css">
+  <link rel="stylesheet" type="text/css" href="/theme/css/style.css">
 
-  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/pygments.css">
+  <link rel="stylesheet" type="text/css" href="/theme/css/pygments.css">
   <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=PT+Sans|PT+Serif|PT+Mono">
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width; initial-scale=1.0">
   <meta name="author" content="{{ AUTHOR }}">
   <meta name="description" content="Posts and writings by {{ AUTHOR }}">
-  <link rel="shortcut icon" href="{{ SITEURL }}/theme/images/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="/theme/images/favicon.ico" type="image/x-icon" />
   {% if FEED_ALL_ATOM %}
   <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Full Atom Feed" />
   {% endif %}


### PR DESCRIPTION
A problem arises if accessing the site through HTTPS when SITEURL is defined as HTTP instead of HTTPS (which make sense). 
The resource will fail to load if accessed as HTTPS with the following message: "The page at 'https://blablabla' was loaded over HTTPS, but ran insecure content from 'http://blablabla/theme/css/style.css': this content should also be loaded over HTTPS."